### PR TITLE
fix: v1.9.3 — phantom-quote filter + date format compat + missing exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-sdk",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -159,15 +159,22 @@ function wallTimeToUTC(wall: ParsedWallClock, tz: string): number {
 }
 
 /**
- * 把 `'HH:mm'` 或 `'HH:mm:ss'` 配合一个基础日期 (YYYY-MM-DD) 组合成完整本地壁钟时间。
+ * 把 `'HH:mm'` 或 `'HH:mm:ss'` 配合一个基础日期组合成完整本地壁钟时间。
  *
  * 用于"当日分时"等场景:接口返回的时间只有 `HH:mm`,日期需要从外层 `date` 字段拿。
+ *
+ * 支持的 baseDate 格式：
+ *  - `YYYY-MM-DD`（带横线）
+ *  - `YYYYMMDD`  （腾讯分时接口的原始格式）
  */
 function combineDateAndTime(
   baseDate: string,
   hhmm: string
 ): ParsedWallClock | null {
-  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec((baseDate || '').trim());
+  const trimmedDate = (baseDate || '').trim();
+  const dateMatch =
+    /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmedDate) ??
+    /^(\d{4})(\d{2})(\d{2})$/.exec(trimmedDate);
   if (!dateMatch) return null;
   const timeMatch = /^(\d{2}):(\d{2})(?::(\d{2}))?$/.exec((hhmm || '').trim());
   if (!timeMatch) return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,19 @@ export type {
   GetAllAShareQuotesOptions,
   AShareMarket,
   GetAShareCodeListOptions,
+  // 美股市场筛选与批量选项类型（之前只在 sdk.ts 内部 re-export，未透到顶层）
+  USMarket,
+  GetUSCodeListOptions,
+  GetAllUSQuotesOptions,
 } from './sdk';
+
+// 交易日历 / 市场状态相关 service 与类型（changelog 已承诺，但之前未透出）
+// 注意：`./sdk` 文件优先于 `./sdk/` 目录，必须显式写 `./sdk/index`
+export {
+  TradingCalendarService,
+  type MarketStatus,
+  type SupportedMarket,
+} from './sdk/index';
 
 // 导出类型
 export * from './types';
@@ -82,6 +94,17 @@ export {
   HttpError,
   SdkError,
   getSdkErrorCode,
+} from './core';
+
+// 时间工具（changelog 已承诺：MARKET_TZ / MarketTz / TimeMeta /
+// parseMarketTime / buildTimeMeta / buildTimeMetaFromDateAndTime）
+export {
+  MARKET_TZ,
+  type MarketTz,
+  type TimeMeta,
+  parseMarketTime,
+  buildTimeMeta,
+  buildTimeMetaFromDateAndTime,
 } from './core';
 
 // 导出配置类型

--- a/src/providers/tencent/fundFlow.ts
+++ b/src/providers/tencent/fundFlow.ts
@@ -19,8 +19,17 @@ export async function getFundFlow(
   }
   const prefixedCodes = codes.map((code) => `ff_${code}`);
   const data = await client.getTencentQuote(prefixedCodes.join(','));
+  // 腾讯无匹配时会返回 v_pv_none_match="1"，按 key 精确过滤；
+  // parseFundFlow 最高访问 f[13]，要求至少 14 个字段。
+  const wanted = new Set(prefixedCodes);
   return data
-    .filter((d) => d.fields && d.fields.length > 0 && d.fields[0] !== '')
+    .filter(
+      (d) =>
+        wanted.has(d.key) &&
+        d.fields &&
+        d.fields.length >= 14 &&
+        d.fields[0] !== ''
+    )
     .map((d) => parseFundFlow(d.fields));
 }
 
@@ -38,8 +47,18 @@ export async function getPanelLargeOrder(
   }
   const prefixedCodes = codes.map((code) => `s_pk${code}`);
   const data = await client.getTencentQuote(prefixedCodes.join(','));
+  // 腾讯无匹配时会返回 v_pv_none_match="1"（fields=['1']），仅靠 fields[0]
+  // 无法识别——它会被解析成 buyLargeRatio: 1 的伪结果。
+  // parsePanelLargeOrder 最高访问 f[3]，要求至少 4 个字段。
+  const wanted = new Set(prefixedCodes);
   return data
-    .filter((d) => d.fields && d.fields.length > 0 && d.fields[0] !== '')
+    .filter(
+      (d) =>
+        wanted.has(d.key) &&
+        d.fields &&
+        d.fields.length >= 4 &&
+        d.fields[0] !== ''
+    )
     .map((d) => parsePanelLargeOrder(d.fields));
 }
 

--- a/src/providers/tencent/fundQuote.ts
+++ b/src/providers/tencent/fundQuote.ts
@@ -19,8 +19,17 @@ export async function getFundQuotes(
   }
   const prefixedCodes = codes.map((code) => `jj${code}`);
   const data = await client.getTencentQuote(prefixedCodes.join(','));
+  // 腾讯无匹配时会返回 v_pv_none_match="1"（fields=['1']），按 key 精确过滤；
+  // 同时校验字段长度满足 parseFundQuote 所需（最高访问 f[8]）。
+  const wanted = new Set(prefixedCodes);
   return data
-    .filter((d) => d.fields && d.fields.length > 0 && d.fields[0] !== '')
+    .filter(
+      (d) =>
+        wanted.has(d.key) &&
+        d.fields &&
+        d.fields.length >= 9 &&
+        d.fields[0] !== ''
+    )
     .map((d) => parseFundQuote(d.fields));
 }
 

--- a/src/providers/tencent/hkQuote.ts
+++ b/src/providers/tencent/hkQuote.ts
@@ -19,8 +19,16 @@ export async function getHKQuotes(
   }
   const prefixedCodes = codes.map((code) => `hk${code}`);
   const data = await client.getTencentQuote(prefixedCodes.join(','));
+  // 腾讯无匹配时会回 v_pv_none_match="1"，按 key 精确过滤
+  const wanted = new Set(prefixedCodes);
   return data
-    .filter((d) => d.fields && d.fields.length > 0 && d.fields[0] !== '')
+    .filter(
+      (d) =>
+        wanted.has(d.key) &&
+        d.fields &&
+        d.fields.length > 5 &&
+        d.fields[0] !== ''
+    )
     .map((d) => parseHKQuote(d.fields));
 }
 

--- a/src/providers/tencent/quote.ts
+++ b/src/providers/tencent/quote.ts
@@ -18,8 +18,17 @@ export async function getFullQuotes(
     return [];
   }
   const data = await client.getTencentQuote(codes.join(','));
+  // 腾讯无匹配时会返回 v_pv_none_match="1"（fields=['1']），靠 fields[0]
+  // 过滤拦不住；这里改成只接受我们请求过的 key，彻底避免"空壳行情"。
+  const wanted = new Set(codes);
   return data
-    .filter((d) => d.fields && d.fields.length > 0 && d.fields[0] !== '')
+    .filter(
+      (d) =>
+        wanted.has(d.key) &&
+        d.fields &&
+        d.fields.length > 5 &&
+        d.fields[0] !== ''
+    )
     .map((d) => parseFullQuote(d.fields));
 }
 
@@ -37,8 +46,15 @@ export async function getSimpleQuotes(
   }
   const prefixedCodes = codes.map((code) => `s_${code}`);
   const data = await client.getTencentQuote(prefixedCodes.join(','));
+  const wanted = new Set(prefixedCodes);
   return data
-    .filter((d) => d.fields && d.fields.length > 0 && d.fields[0] !== '')
+    .filter(
+      (d) =>
+        wanted.has(d.key) &&
+        d.fields &&
+        d.fields.length > 5 &&
+        d.fields[0] !== ''
+    )
     .map((d) => parseSimpleQuote(d.fields));
 }
 

--- a/src/providers/tencent/timeline.ts
+++ b/src/providers/tencent/timeline.ts
@@ -11,6 +11,35 @@ import {
 import type { TodayTimeline, TodayTimelineResponse } from '../../types';
 
 /**
+ * 腾讯分时接口里单只股票的 payload 形状：
+ *   {
+ *     data: { data: ['0930 11.47 ...', ...], date: '20260522' },
+ *     qt:   { 'sz000001': [field0, field1, ...] }
+ *   }
+ *
+ * 拆成独立 interface 主要为了在 TS 严格模式下避免使用 `any`，
+ * 并把后续字段访问（rawData / date / preClose）的语义集中标注。
+ */
+interface TencentStockTimelineInner {
+  /** 分时点字符串数组，格式："HHmm 价格 累计成交量 累计成交额" */
+  data?: string[];
+  /** 日期字符串：腾讯返回 YYYYMMDD，但保险起见两种格式都允许 */
+  date?: string;
+}
+
+interface TencentStockTimeline {
+  data?: TencentStockTimelineInner;
+  /** quote fields 字典，key 为股票代码，value 是行情字段数组 */
+  qt?: Record<string, string[] | undefined>;
+}
+
+interface TencentTimelineResponse {
+  code?: number;
+  msg?: string;
+  data?: Record<string, TencentStockTimeline | undefined>;
+}
+
+/**
  * 获取当日分时走势数据
  * @param client 请求客户端
  * @param code 股票代码，如 'sz000001' 或 'sh600000'
@@ -19,98 +48,86 @@ export async function getTodayTimeline(
   client: RequestClient,
   code: string
 ): Promise<TodayTimelineResponse> {
-  const timeout = client.getTimeout();
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  // 走 RequestClient 以继承 retry / rateLimit / circuitBreaker / providerPolicies /
+  // host fallback；之前用裸 fetch 导致此接口与同实例其它接口的请求治理行为不一致。
+  const url = `${TENCENT_MINUTE_URL}?code=${encodeURIComponent(code)}`;
+  const json = await client.get<TencentTimelineResponse>(url, {
+    responseType: 'json',
+    provider: 'tencent',
+  });
 
-  try {
-    const resp = await fetch(`${TENCENT_MINUTE_URL}?code=${code}`, {
-      signal: controller.signal,
-    });
+  if (json.code !== 0) {
+    throw new Error(json.msg || 'API error');
+  }
 
-    if (!resp.ok) {
-      throw new Error(`HTTP error! status: ${resp.status}`);
-    }
-
-    const json = await resp.json();
-
-    if (json.code !== 0) {
-      throw new Error(json.msg || 'API error');
-    }
-
-    const stockData = json.data?.[code];
-    if (!stockData) {
-      const emptyMeta = buildTimeMeta('', MARKET_TZ.CN);
-      return {
-        code,
-        date: '',
-        timestamp: emptyMeta.timestamp,
-        tz: emptyMeta.tz,
-        preClose: 0,
-        data: [],
-      };
-    }
-
-    const rawData: string[] = stockData.data?.data || [];
-    const date: string = stockData.data?.date || '';
-    const quoteFields = Array.isArray(stockData.qt?.[code])
-      ? stockData.qt[code]
-      : [];
-    const preClose = parseFloat(quoteFields[4] ?? '') || 0;
-
-    // 解析分时数据："0930 11.47 1715 1967105.00"
-    // 格式：时间 成交价 累计成交量 累计成交额
-    // 注意：接口返回的成交量单位不一致，主板/创业板是"手"，科创板是"股"
-    // 需要通过首条数据的 成交额/成交量 与 价格 的比值来判断单位
-    // 输出统一为"股"
-    let isVolumeInLots = false; // 成交量是否以"手"为单位
-    if (rawData.length > 0) {
-      const firstParts = rawData[0].split(' ');
-      const firstPrice = parseFloat(firstParts[1]) || 0;
-      const firstVolume = parseInt(firstParts[2], 10) || 0;
-      const firstAmount = parseFloat(firstParts[3]) || 0;
-      if (firstVolume > 0 && firstPrice > 0) {
-        // 计算 成交额/成交量，如果接近 价格×100，说明单位是"手"
-        const ratio = firstAmount / firstVolume;
-        if (ratio > firstPrice * 50) {
-          isVolumeInLots = true;
-        }
-      }
-    }
-
-    const data: TodayTimeline[] = rawData.map((line: string) => {
-      const parts = line.split(' ');
-      const timeRaw = parts[0]; // "0930"
-      const time = `${timeRaw.slice(0, 2)}:${timeRaw.slice(2, 4)}`; // "09:30"
-      const rawVolume = parseInt(parts[2], 10) || 0;
-      const amount = parseFloat(parts[3]) || 0;
-      // 统一成交量为"股"：如果原始单位是"手"，则乘以 100
-      const volume = isVolumeInLots ? rawVolume * 100 : rawVolume;
-      // 计算均价：累计成交额 / 累计成交量（股）
-      const avgPrice = volume > 0 ? amount / volume : 0;
-      // 利用外层 `date` (YYYY-MM-DD) 与本行 `HH:mm` 拼接出 UTC 时间戳
-      const tickMeta = buildTimeMetaFromDateAndTime(date, time, MARKET_TZ.CN);
-      return {
-        time,
-        timestamp: tickMeta.timestamp,
-        tz: tickMeta.tz,
-        price: parseFloat(parts[1]) || 0,
-        volume,
-        amount,
-        avgPrice: Math.round(avgPrice * 100) / 100, // 保留两位小数
-      };
-    });
-
-    const dayMeta = buildTimeMeta(date, MARKET_TZ.CN);
+  const stockData = json.data?.[code];
+  if (!stockData) {
+    const emptyMeta = buildTimeMeta('', MARKET_TZ.CN);
     return {
       code,
-      date,
-      timestamp: dayMeta.timestamp,
-      tz: dayMeta.tz,
-      preClose,
-      data,
+      date: '',
+      timestamp: emptyMeta.timestamp,
+      tz: emptyMeta.tz,
+      preClose: 0,
+      data: [],
     };
-  } finally {
-    clearTimeout(timeoutId);
   }
+
+  const rawData: string[] = stockData.data?.data ?? [];
+  const date: string = stockData.data?.date ?? '';
+  const quoteFields: string[] = stockData.qt?.[code] ?? [];
+  const preClose = parseFloat(quoteFields[4] ?? '') || 0;
+
+  // 解析分时数据："0930 11.47 1715 1967105.00"
+  // 格式：时间 成交价 累计成交量 累计成交额
+  // 注意：接口返回的成交量单位不一致，主板/创业板是"手"，科创板是"股"
+  // 需要通过首条数据的 成交额/成交量 与 价格 的比值来判断单位
+  // 输出统一为"股"
+  let isVolumeInLots = false; // 成交量是否以"手"为单位
+  if (rawData.length > 0) {
+    const firstParts = rawData[0].split(' ');
+    const firstPrice = parseFloat(firstParts[1]) || 0;
+    const firstVolume = parseInt(firstParts[2], 10) || 0;
+    const firstAmount = parseFloat(firstParts[3]) || 0;
+    if (firstVolume > 0 && firstPrice > 0) {
+      // 计算 成交额/成交量，如果接近 价格×100，说明单位是"手"
+      const ratio = firstAmount / firstVolume;
+      if (ratio > firstPrice * 50) {
+        isVolumeInLots = true;
+      }
+    }
+  }
+
+  const data: TodayTimeline[] = rawData.map((line: string) => {
+    const parts = line.split(' ');
+    const timeRaw = parts[0]; // "0930"
+    const time = `${timeRaw.slice(0, 2)}:${timeRaw.slice(2, 4)}`; // "09:30"
+    const rawVolume = parseInt(parts[2], 10) || 0;
+    const amount = parseFloat(parts[3]) || 0;
+    // 统一成交量为"股"：如果原始单位是"手"，则乘以 100
+    const volume = isVolumeInLots ? rawVolume * 100 : rawVolume;
+    // 计算均价：累计成交额 / 累计成交量（股）
+    const avgPrice = volume > 0 ? amount / volume : 0;
+    // 利用外层 `date`（YYYYMMDD 或 YYYY-MM-DD）与本行 `HH:mm` 拼接出 UTC 时间戳
+    const tickMeta = buildTimeMetaFromDateAndTime(date, time, MARKET_TZ.CN);
+    return {
+      time,
+      timestamp: tickMeta.timestamp,
+      tz: tickMeta.tz,
+      price: parseFloat(parts[1]) || 0,
+      volume,
+      amount,
+      avgPrice: Math.round(avgPrice * 100) / 100, // 保留两位小数
+    };
+  });
+
+  const dayMeta = buildTimeMeta(date, MARKET_TZ.CN);
+  return {
+    code,
+    date,
+    timestamp: dayMeta.timestamp,
+    tz: dayMeta.tz,
+    preClose,
+    data,
+  };
 }

--- a/src/providers/tencent/usQuote.ts
+++ b/src/providers/tencent/usQuote.ts
@@ -19,8 +19,16 @@ export async function getUSQuotes(
   }
   const prefixedCodes = codes.map((code) => `us${code}`);
   const data = await client.getTencentQuote(prefixedCodes.join(','));
+  // 腾讯无匹配时会回 v_pv_none_match="1"，按 key 精确过滤
+  const wanted = new Set(prefixedCodes);
   return data
-    .filter((d) => d.fields && d.fields.length > 0 && d.fields[0] !== '')
+    .filter(
+      (d) =>
+        wanted.has(d.key) &&
+        d.fields &&
+        d.fields.length > 5 &&
+        d.fields[0] !== ''
+    )
     .map((d) => parseUSQuote(d.fields));
 }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -161,7 +161,7 @@ export class StockSDK {
 
   /**
    * 获取港股行情
-   * @param codes 港股代码数组（如 `['hk00700']`）
+   * @param codes 港股代码数组（5 位数字，无需 `hk` 前缀，如 `['00700', '09988']`）
    */
   getHKQuotes(codes: string[]): Promise<HKQuote[]> {
     return this.quoteService.getHKQuotes(codes);
@@ -169,7 +169,7 @@ export class StockSDK {
 
   /**
    * 获取美股行情
-   * @param codes 美股代码数组（如 `['usAAPL']`）
+   * @param codes 美股代码数组（无需 `us` 前缀，如 `['AAPL', 'BABA']`）
    */
   getUSQuotes(codes: string[]): Promise<USQuote[]> {
     return this.quoteService.getUSQuotes(codes);

--- a/src/sdk/indicatorService.ts
+++ b/src/sdk/indicatorService.ts
@@ -58,11 +58,13 @@ export class IndicatorService {
     tradingDays: number,
     ratio: number = 1.5
   ): string {
+    // 兼容 'YYYY-MM-DD' 与 'YYYYMMDD' 两种入参：先归一成紧凑格式再 slice
+    const compact = this.toCompactDate(startDate);
     const naturalDays = Math.ceil(tradingDays * ratio);
     const date = new Date(
-      parseInt(startDate.slice(0, 4)),
-      parseInt(startDate.slice(4, 6)) - 1,
-      parseInt(startDate.slice(6, 8))
+      parseInt(compact.slice(0, 4)),
+      parseInt(compact.slice(4, 6)) - 1,
+      parseInt(compact.slice(6, 8))
     );
     date.setDate(date.getDate() - naturalDays);
 
@@ -149,7 +151,9 @@ export class IndicatorService {
       period: options.period,
       adjust: options.adjust,
       startDate: actualStartDate,
-      endDate: options.endDate,
+      // provider 透传到东方财富的 beg/end 仅接受 YYYYMMDD，
+      // 这里统一归一化，避免 'YYYY-MM-DD' 入参导致 HK/US 返回 0 条
+      endDate: options.endDate ? this.toCompactDate(options.endDate) : undefined,
     };
 
     let allKlines: (HistoryKline | HKUSHistoryKline)[];

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -2,6 +2,57 @@
 
 本页面记录 Stock SDK 的版本更新历史。
 
+## **[1.9.3](https://www.npmjs.com/package/stock-sdk/v/1.9.3)** (2026-05-22)
+
+> Bug fix 版本。集中修复 v1.9.0 / v1.9.2 后发现的 7 个真实问题，无破坏性变更。
+
+### 修复
+
+**腾讯无效代码"空壳行情"**
+- 之前所有腾讯行情接口只过滤 `fields[0] !== ''`，但腾讯对无匹配代码会返回
+  `v_pv_none_match="1"`（`fields = ['1']`）通过过滤后被解析成 `code: ''`、`price: 0` 的伪数据。
+- 修复 7 个入口：`getFullQuotes` / `getSimpleQuotes` / `getHKQuotes` / `getUSQuotes` /
+  `getFundQuotes` / `getFundFlow` / `getPanelLargeOrder`。
+- 改为按响应 `key` 精确匹配请求过的代码集合，并按各 parser 实际使用的最大字段下标收紧长度校验。
+
+**时间戳解析**
+- `getTodayTimeline` 每个分时点 `timestamp: NaN` — 腾讯返回 `date=YYYYMMDD`，
+  但内部 `combineDateAndTime` 仅接受 `YYYY-MM-DD`。修复 `core/time.ts` 同时兼容两种格式。
+- `getKlineWithIndicators` 用 `YYYY-MM-DD` 起止日期时 HK/US 返回 0 条 —
+  `calcActualStartDate` 切片前未归一化导致非法日期、`endDate` 又原样透传给 provider。
+  两处都统一转 `YYYYMMDD` 再交给 provider。
+
+**请求治理一致性**
+- `getTodayTimeline` 之前用裸 `fetch` 绕过了 retry / rateLimit / circuitBreaker / providerPolicies /
+  host fallback，与同一 SDK 实例的其它接口治理行为不一致。改为统一走 `RequestClient.get`。
+
+**JSDoc 误导**
+- `getHKQuotes` / `getUSQuotes` 示例代码写成已经带前缀的 `'hk00700'` / `'usAAPL'`，
+  会被 provider 再加一次前缀变成无效查询。改为无前缀的 `'00700'` / `'AAPL'`。
+
+### 补齐导出（履行历史 changelog 承诺）
+
+`src/index.ts` 之前列在 changelog 但实际未对外 re-export 的符号现已补齐：
+- **时间工具**：`MARKET_TZ` / `MarketTz` / `TimeMeta` / `parseMarketTime` /
+  `buildTimeMeta` / `buildTimeMetaFromDateAndTime`
+- **服务类与类型**：`TradingCalendarService` / `MarketStatus` / `SupportedMarket`
+- **美股相关**：`USMarket` / `GetUSCodeListOptions` / `GetAllUSQuotesOptions`
+
+TypeScript 用户现在可以从 `stock-sdk` 顶层直接 import。
+
+### 内部优化
+
+- `providers/tencent/timeline.ts` 去 `any` 化：新增 3 个本地 interface
+  （`TencentTimelineResponse` / `TencentStockTimeline` / `TencentStockTimelineInner`）
+  明确响应结构，符合项目零 `any` 规范。
+
+### 兼容性
+
+- 本版本不包含破坏性变更。
+- 唯一行为差异是"无效代码不再返回伪数据"——以前会拿到 `code: ''`、`price: 0` 的占位行情，
+  现在直接被过滤掉。如果有调用方依赖这种占位返回，需要补一下空数组处理。
+
+
 ## **[1.9.2](https://www.npmjs.com/package/stock-sdk/v/1.9.2)** (2026-05-16)
 
 > 数据契约清理 + 业务工具补齐版本。**全部为非破坏性新增**，老代码无需迁移即可升级。

--- a/website/en/changelog.md
+++ b/website/en/changelog.md
@@ -2,6 +2,63 @@
 
 This page records the version update history of Stock SDK.
 
+## **[1.9.3](https://www.npmjs.com/package/stock-sdk/v/1.9.3)** (2026-05-22)
+
+> Bug fix release. Resolves 7 issues discovered after v1.9.0 / v1.9.2. **No breaking changes.**
+
+### Bug Fixes
+
+**Tencent "phantom quote" for invalid codes**
+- All Tencent quote endpoints previously filtered only on `fields[0] !== ''`. For unmatched codes,
+  Tencent returns `v_pv_none_match="1"` (`fields = ['1']`) which passed the filter and was parsed
+  into a placeholder result with `code: ''`, `price: 0`.
+- Fixed across 7 entry points: `getFullQuotes` / `getSimpleQuotes` / `getHKQuotes` / `getUSQuotes` /
+  `getFundQuotes` / `getFundFlow` / `getPanelLargeOrder`.
+- New behavior: filter by exact response `key` membership against the requested code set, plus a
+  field-length threshold tuned to each parser's highest accessed index.
+
+**Timestamp parsing**
+- `getTodayTimeline` per-tick `timestamp: NaN` — Tencent returns `date=YYYYMMDD`, but the
+  internal `combineDateAndTime` only accepted `YYYY-MM-DD`. Fixed `core/time.ts` to accept both.
+- `getKlineWithIndicators` returning 0 bars on HK / US when start/end dates were in `YYYY-MM-DD`
+  format — `calcActualStartDate` sliced unmodified input (producing garbage dates) and `endDate`
+  was passed through unchanged. Both sites now normalize to `YYYYMMDD` before reaching the
+  provider.
+
+**Request governance consistency**
+- `getTodayTimeline` previously used raw `fetch`, bypassing retry / rateLimit / circuitBreaker /
+  providerPolicies / host fallback. Now routed through `RequestClient.get` so its governance
+  matches every other endpoint in the same SDK instance.
+
+**Misleading JSDoc**
+- `getHKQuotes` / `getUSQuotes` examples showed already-prefixed codes
+  (`'hk00700'` / `'usAAPL'`), which the provider then re-prefixed, breaking the query.
+  Examples now use the correct un-prefixed form (`'00700'` / `'AAPL'`).
+
+### Restored exports (fulfilling earlier changelog promises)
+
+`src/index.ts` now actually re-exports the symbols previously listed in the changelog:
+- **Time helpers**: `MARKET_TZ` / `MarketTz` / `TimeMeta` / `parseMarketTime` /
+  `buildTimeMeta` / `buildTimeMetaFromDateAndTime`
+- **Service & types**: `TradingCalendarService` / `MarketStatus` / `SupportedMarket`
+- **US-market types**: `USMarket` / `GetUSCodeListOptions` / `GetAllUSQuotesOptions`
+
+TypeScript users can now import these directly from `stock-sdk`.
+
+### Internal
+
+- `providers/tencent/timeline.ts` no longer uses `any`. Three local interfaces
+  (`TencentTimelineResponse` / `TencentStockTimeline` / `TencentStockTimelineInner`)
+  describe the Tencent response shape, in line with the project's no-`any` policy.
+
+### Compatibility
+
+- No breaking changes.
+- The only behavioral difference: invalid codes no longer return placeholder quotes.
+  If your code relied on receiving a `code: ''`, `price: 0` row, you'll now get an empty array
+  and need to handle that explicitly.
+
+
 ## **[1.9.2](https://www.npmjs.com/package/stock-sdk/v/1.9.2)** (2026-05-16)
 
 > Data-contract cleanup + business helper additions. **All changes are non-breaking**;

--- a/website/summary.md
+++ b/website/summary.md
@@ -5,7 +5,7 @@
 ## 项目定位
 
 - 包名：`stock-sdk`
-- 当前版本：`1.9.2`
+- 当前版本：`1.9.3`
 - 定位：面向前端与 Node.js 的股票行情 SDK，支持多市场行情、K 线、指标、期货、期权和 AI / MCP 集成
 - 核心卖点：零依赖 | Browser + Node.js | 轻量发布包 | 完整 TypeScript 类型
 
@@ -13,8 +13,8 @@
 
 | 文件 | 体积 | Gzip |
 | --- | --- | --- |
-| `dist/index.js` | 101.68 KB | 28.97 KB |
-| `dist/index.cjs` | 102.52 KB | 29.40 KB |
+| `dist/index.js` | 101.96 KB | 29.04 KB |
+| `dist/index.cjs` | 102.90 KB | 29.51 KB |
 
 ## 请求治理能力
 


### PR DESCRIPTION
## Summary

v1.9.3 patch release — fixes 7 issues discovered after v1.9.0 / v1.9.2. **No breaking changes.**

Split into 3 commits for review:

| Commit | Subject |
|--------|---------|
| `6b224c7` | `fix(tencent)`: block phantom quotes from invalid codes + fix HK/US JSDoc |
| `80d8aad` | `fix`: date format compat + route getTodayTimeline through RequestClient |
| `f68ee50` | `chore(release)`: expose missing helpers + bump 1.9.3 + changelog |

## Bug fixes

### Tencent "phantom quote" for invalid codes (commit 1)

All Tencent quote endpoints previously filtered only on \`fields[0] !== ''\`. For unmatched codes, tencent returns \`v_pv_none_match=\"1\"\` (\`fields=['1']\`) which passed the filter and was parsed into a placeholder \`code: ''\`, \`price: 0\` result.

Fixed across 7 entry points: \`getFullQuotes\` / \`getSimpleQuotes\` / \`getHKQuotes\` / \`getUSQuotes\` / \`getFundQuotes\` / \`getFundFlow\` / \`getPanelLargeOrder\`.

New filter: exact key membership against requested code set + field-length threshold tuned per parser.

Also fixes misleading JSDoc on \`getHKQuotes\` / \`getUSQuotes\` (\`'hk00700'\` / \`'usAAPL'\` examples that got double-prefixed).

### Timestamp / date format (commit 2)

- \`getTodayTimeline\` per-tick \`timestamp: NaN\` — \`core/time.ts\` \`combineDateAndTime\` now accepts both \`YYYYMMDD\` and \`YYYY-MM-DD\`.
- \`getKlineWithIndicators\` returning 0 bars on HK / US when given ISO dates — \`indicatorService\` now normalises both \`startDate\` and \`endDate\` to \`YYYYMMDD\` before passing to the provider.

### Request governance (commit 2)

\`getTodayTimeline\` was using raw \`fetch\`, bypassing retry / rateLimit / circuitBreaker / providerPolicies / host fallback. Now routed through \`RequestClient.get\`.

Also removed \`any\` from \`timeline.ts\` by adding 3 local interfaces (\`TencentTimelineResponse\` etc.) — matches the project's no-\`any\` policy.

### Missing exports (commit 3)

\`src/index.ts\` now actually re-exports symbols previously listed in changelog but never made it to the top-level entry:

- **Time helpers**: \`MARKET_TZ\` / \`MarketTz\` / \`TimeMeta\` / \`parseMarketTime\` / \`buildTimeMeta\` / \`buildTimeMetaFromDateAndTime\`
- **Service & types**: \`TradingCalendarService\` / \`MarketStatus\` / \`SupportedMarket\`
- **US-market types**: \`USMarket\` / \`GetUSCodeListOptions\` / \`GetAllUSQuotesOptions\`

## Compatibility

- No breaking changes to method signatures or return shapes.
- Only behavioural difference: invalid codes no longer return placeholder quotes (\`code: ''\`, \`price: 0\`) — if any consumer relied on that, they'll now get an empty array.

## Test plan

- [x] \`yarn typecheck\` — pass
- [x] \`yarn test\` — 31 files, 293 tests pass
- [x] \`yarn build\` — CJS / ESM / DTS all green
- [x] \`yarn docs:check\` — pass (summary.md auto-regenerated by pre-commit hook)