### PR TITLE
fix(deps): shiki 提为直接依赖 + CI 增加 docs 构建（修 v2.0.0 docs 部署）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,9 @@ jobs:
 
       - name: Documentation consistency
         run: pnpm docs:check
+
+      # 跑一次完整 vitepress 构建，确保文档站能在干净（pnpm 严格）安装下构建。
+      # 否则 docs-only 的依赖问题（如 Playground 引用的 shiki 幽灵依赖）只有合并后
+      # 的 docs.yml 部署才会暴露，PR 阶段拦不住。
+      - name: Build docs site
+        run: pnpm build:pages

--- a/package.json
+++ b/package.json
@@ -36,32 +36,74 @@
       }
     },
     "./indicators": {
-      "import": { "types": "./dist/indicators.d.ts", "default": "./dist/indicators.js" },
-      "require": { "types": "./dist/indicators.d.cts", "default": "./dist/indicators.cjs" }
+      "import": {
+        "types": "./dist/indicators.d.ts",
+        "default": "./dist/indicators.js"
+      },
+      "require": {
+        "types": "./dist/indicators.d.cts",
+        "default": "./dist/indicators.cjs"
+      }
     },
     "./symbols": {
-      "import": { "types": "./dist/symbols.d.ts", "default": "./dist/symbols.js" },
-      "require": { "types": "./dist/symbols.d.cts", "default": "./dist/symbols.cjs" }
+      "import": {
+        "types": "./dist/symbols.d.ts",
+        "default": "./dist/symbols.js"
+      },
+      "require": {
+        "types": "./dist/symbols.d.cts",
+        "default": "./dist/symbols.cjs"
+      }
     },
     "./signals": {
-      "import": { "types": "./dist/signals.d.ts", "default": "./dist/signals.js" },
-      "require": { "types": "./dist/signals.d.cts", "default": "./dist/signals.cjs" }
+      "import": {
+        "types": "./dist/signals.d.ts",
+        "default": "./dist/signals.js"
+      },
+      "require": {
+        "types": "./dist/signals.d.cts",
+        "default": "./dist/signals.cjs"
+      }
     },
     "./screener": {
-      "import": { "types": "./dist/screener.d.ts", "default": "./dist/screener.js" },
-      "require": { "types": "./dist/screener.d.cts", "default": "./dist/screener.cjs" }
+      "import": {
+        "types": "./dist/screener.d.ts",
+        "default": "./dist/screener.js"
+      },
+      "require": {
+        "types": "./dist/screener.d.cts",
+        "default": "./dist/screener.cjs"
+      }
     },
     "./cache": {
-      "import": { "types": "./dist/cache.d.ts", "default": "./dist/cache.js" },
-      "require": { "types": "./dist/cache.d.cts", "default": "./dist/cache.cjs" }
+      "import": {
+        "types": "./dist/cache.d.ts",
+        "default": "./dist/cache.js"
+      },
+      "require": {
+        "types": "./dist/cache.d.cts",
+        "default": "./dist/cache.cjs"
+      }
     },
     "./errors": {
-      "import": { "types": "./dist/errors.d.ts", "default": "./dist/errors.js" },
-      "require": { "types": "./dist/errors.d.cts", "default": "./dist/errors.cjs" }
+      "import": {
+        "types": "./dist/errors.d.ts",
+        "default": "./dist/errors.js"
+      },
+      "require": {
+        "types": "./dist/errors.d.cts",
+        "default": "./dist/errors.cjs"
+      }
     },
     "./mcp": {
-      "import": { "types": "./dist/mcp.d.ts", "default": "./dist/mcp.js" },
-      "require": { "types": "./dist/mcp.d.cts", "default": "./dist/mcp.cjs" }
+      "import": {
+        "types": "./dist/mcp.d.ts",
+        "default": "./dist/mcp.js"
+      },
+      "require": {
+        "types": "./dist/mcp.d.cts",
+        "default": "./dist/mcp.cjs"
+      }
     },
     "./package.json": "./package.json"
   },
@@ -110,6 +152,7 @@
     "@vitest/coverage-v8": "^4.0.16",
     "msw": "^2.10.4",
     "playwright": "^1.58.2",
+    "shiki": "^2.5.0",
     "tsup": "^8.3.5",
     "typescript": "^5.9.3",
     "vitepress": "^1.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
+      shiki:
+        specifier: ^2.5.0
+        version: 2.5.0
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)


### PR DESCRIPTION
## 背景

v2.0.0 合并后 `docs.yml` 部署失败：

\`\`\`
[vite]: Rollup failed to resolve import "shiki" from website/.vitepress/theme/components/Playground.vue
\`\`\`

`Playground.vue` 直接 `import { codeToHtml } from 'shiki'`，但 shiki 只是 vitepress 的传递依赖。yarn 扁平 node_modules 下能解析（幽灵依赖），迁移到 pnpm 严格 node_modules 后、干净安装下 shiki 不在顶层无法解析。npm 发布的 SDK 包不受影响（shiki 仅文档站用）。

## 改动

- **package.json**：新增 `shiki@^2.5.0` 直接 devDependency（与 vitepress 的 `^2.1.0` dedup 到同一份 2.5.0，无额外下载）
- **.github/workflows/ci.yml**：verify job 增加 `pnpm build:pages` 步骤，让 vitepress 完整构建在 PR 阶段就跑——此前 ci.yml 只跑 tsup，docs-only 依赖问题要等合并后 docs.yml 部署才暴露

## 验证

`rm -rf node_modules && pnpm install --frozen-lockfile`（复现 CI 干净安装）后：typecheck / test 976 / docs:check / `build:pages` 全绿。