### PR TITLE
feat(website): 顶部 v2 升级提示条 + 暂时下线 AI 问答助手入口

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "test:integration": "RUN_INTEGRATION=1 vitest run",
     "test:integration:smoke": "RUN_INTEGRATION=1 vitest run test/integration/providers/tencent/quote.int.test.ts test/integration/providers/tencent/batch.int.test.ts test/integration/providers/tencent/tradeCalendar.int.test.ts test/integration/sdk/timeout.int.test.ts",
     "test:integration:full": "RUN_INTEGRATION=1 vitest run test/integration",
-    "docs:meta": "yarn build && node ./scripts/generate-doc-meta.js",
-    "docs:check": "yarn build && node ./scripts/check-doc-consistency.js",
+    "docs:meta": "node -e \"console.log('website is frozen at stock-sdk@1.10.1; skip docs metadata regeneration')\"",
+    "docs:check": "DOCS_BASE=/ vitepress build website",
     "dev": "vitepress dev website",
     "preview": "vitepress preview website",
-    "build:docs": "yarn docs:meta && DOCS_BASE=/ vitepress build website",
-    "build:pages": "yarn docs:meta && DOCS_BASE=/stock-sdk/ vitepress build website",
+    "build:docs": "DOCS_BASE=/ vitepress build website",
+    "build:pages": "DOCS_BASE=/stock-sdk/ vitepress build website",
     "prepare": "node ./scripts/install-git-hooks.js"
   },
   "exports": {

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -1,16 +1,10 @@
 import { defineConfig } from 'vitepress'
-import { resolve } from 'path'
-import { readFileSync } from 'fs'
 import faroUploader from '@grafana/faro-rollup-plugin'
 
 const base = process.env.DOCS_BASE || '/'
 
-// 构建期读取真实版本号，注入 themeConfig 供 HeroMeta 等组件使用（避免硬编码失真）
-const sdkVersion = (
-  JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')) as {
-    version: string
-  }
-).version
+// v1 文档站已封存，不能再跟随根包升级到 v2。
+const sdkVersion = '1.10.1'
 
 // MCP 中文侧边栏配置
 const zhMcpSidebar = {
@@ -470,17 +464,7 @@ export default defineConfig({
 
   // Vite 配置
   vite: {
-    resolve: {
-      alias: {
-        // 开发模式下将 'stock-sdk-local' 指向本地 src 目录
-        'stock-sdk-local': resolve(__dirname, '../../src'),
-      },
-    },
     server: {
-      fs: {
-        // 允许访问上级目录（用于引用 src）
-        allow: ['../..'],
-      },
       // 本地开发反向代理:把 /api/llm/* 转发到本地运行的 api-worker(文档问答 agent)。
       // ⚠️ 只代理 /api/llm,绝不能用 /api —— 因为本站的 API 文档页就在 /api/* 路径下
       //    (如 /api/kline、/api/quotes),用 /api 会把文档页也代理走导致 404。

--- a/website/.vitepress/env.d.ts
+++ b/website/.vitepress/env.d.ts
@@ -1,16 +1,7 @@
 /// <reference types="vite/client" />
 
-// 声明 stock-sdk-local 模块（开发模式下指向本地 src）
-// 这个模块在 Vite 配置中被别名到 ../../src
-declare module 'stock-sdk-local' {
-  // 使用 any 类型，因为这是运行时解析的别名
+// 声明 v1 文档站固定使用的 CDN SDK 入口。
+declare module 'https://unpkg.com/stock-sdk@1.10.1/dist/index.js' {
   export const StockSDK: any
   export default StockSDK
 }
-
-// 声明动态 URL 导入模块（用于生产环境的 unpkg CDN）
-declare module 'https://unpkg.com/stock-sdk/dist/index.js' {
-  export const StockSDK: any
-  export default StockSDK
-}
-

--- a/website/.vitepress/theme/Layout.vue
+++ b/website/.vitepress/theme/Layout.vue
@@ -8,6 +8,7 @@
  *   - home-hero-actions-after → 次级 inline 链接（API / MCP / GitHub）
  *
  * 全站插槽：
+ *   - layout-top    → V2Banner（顶部「升级到 v2」提示条，可关闭，每个页面都有）
  *   - layout-bottom → ChatBot（右下角悬浮文档问答助手，每个页面都有）
  */
 import DefaultTheme from 'vitepress/theme'
@@ -15,7 +16,9 @@ import { useData, withBase } from 'vitepress'
 import { computed } from 'vue'
 import LiveTicker from './components/LiveTicker.vue'
 import HeroMeta from './components/HeroMeta.vue'
-import ChatBot from './components/chat/ChatBot.vue'
+import V2Banner from './components/V2Banner.vue'
+// 暂时关闭全站悬浮 AI 问答助手入口；恢复时取消本行与下方 layout-bottom 插槽的注释即可
+// import ChatBot from './components/chat/ChatBot.vue'
 
 const { Layout } = DefaultTheme
 const { lang } = useData()
@@ -48,6 +51,11 @@ function href(l: HeroLink): string {
 
 <template>
   <Layout>
+    <!-- 全站顶部「升级到 v2」提示条（可关闭） -->
+    <template #layout-top>
+      <V2Banner />
+    </template>
+
     <template #home-hero-info-after>
       <HeroMeta />
     </template>
@@ -69,9 +77,12 @@ function href(l: HeroLink): string {
       </div>
     </template>
 
-    <!-- 全站悬浮文档问答助手 -->
+    <!-- 全站悬浮文档问答助手（暂时关闭，恢复时取消注释并放开上方 import） -->
+    <!--
     <template #layout-bottom>
       <ChatBot />
     </template>
+    -->
+
   </Layout>
 </template>

--- a/website/.vitepress/theme/components/LiveTicker.vue
+++ b/website/.vitepress/theme/components/LiveTicker.vue
@@ -81,7 +81,8 @@ function stampNow(): void {
   time.value = `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
 }
 
-// ---- SDK 加载（与 Playground 同款双模式：dev 引本地 src，prod 走 unpkg）----
+// ---- SDK 加载：v1 文档站固定使用 stock-sdk@1.10.1 ----
+const SDK_CDN_URL = 'https://unpkg.com/stock-sdk@1.10.1/dist/index.js'
 let sdk: any = null
 let sdkLoading: Promise<any> | null = null
 
@@ -89,10 +90,7 @@ async function loadSDK(): Promise<any> {
   if (sdk) return sdk
   if (sdkLoading) return sdkLoading
   sdkLoading = (async () => {
-    const isDev = import.meta.env.DEV
-    const mod: any = isDev
-      ? await import('stock-sdk-local')
-      : await import(/* @vite-ignore */ 'https://unpkg.com/stock-sdk/dist/index.js')
+    const mod: any = await import(/* @vite-ignore */ SDK_CDN_URL)
     const StockSDK = mod.StockSDK || mod.default
     sdk = new StockSDK({ timeout: 8000, retry: { maxRetries: 1, baseDelay: 600 } })
     return sdk

--- a/website/.vitepress/theme/components/Playground.vue
+++ b/website/.vitepress/theme/components/Playground.vue
@@ -346,21 +346,14 @@ function clearResult() {
 }
 
 // === SDK 加载与重建 ===
-// SDKClass 缓存避免每次 apply 配置都重新 fetch unpkg。
+// v1 文档站固定使用 stock-sdk@1.10.1；SDKClass 缓存避免每次 apply 配置都重新 fetch unpkg。
+const SDK_CDN_URL = 'https://unpkg.com/stock-sdk@1.10.1/dist/index.js'
 let cachedSDKClass: any = null
 
 async function loadSDKClass() {
   if (cachedSDKClass) return cachedSDKClass
-  const isDev = import.meta.env.DEV
-  if (isDev) {
-    // 本地开发：直接引用 src 源码
-    const module = (await import('stock-sdk-local')) as any
-    cachedSDKClass = module.StockSDK || module.default
-  } else {
-    // 生产环境：从 unpkg 加载
-    const module = (await import('https://unpkg.com/stock-sdk/dist/index.js')) as any
-    cachedSDKClass = module.StockSDK
-  }
+  const module = (await import(/* @vite-ignore */ SDK_CDN_URL)) as any
+  cachedSDKClass = module.StockSDK || module.default
   return cachedSDKClass
 }
 

--- a/website/.vitepress/theme/components/V2Banner.vue
+++ b/website/.vitepress/theme/components/V2Banner.vue
@@ -1,0 +1,245 @@
+<script setup lang="ts">
+/**
+ * V2Banner —— 全站顶部「升级到 v2」提示条。
+ *
+ * 背景：本站是封存的 v1 文档（sdkVersion 锁在 1.10.1），v2 文档站已上线，
+ * 这条横幅引导访客前往 v2，并明确告知当前看到的是 v1。
+ *
+ * 机制（VitePress 官方公告栏模式）：
+ *  - 横幅 position:fixed 占据视口顶部一条；
+ *  - 把横幅实测高度写入 CSS 变量 --vp-layout-top-height，VitePress 默认主题会
+ *    据此把固定导航 / 内容 / 侧边栏整体下移，互不遮挡（无需手改主题）。
+ *
+ * 可关闭：点 × 后写入 localStorage，后续访问不再出现；想重新弹出（例如 v2 有
+ * 大更新需要再次提醒）时把 DISMISS_KEY 末尾的版本号 +1 即可。
+ *
+ * SSR 安全：服务端渲染阶段 visible=false（渲染空），仅在 onMounted（浏览器）里
+ * 读 localStorage 决定是否展示，避免 hydration 不匹配。
+ */
+import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { useData } from 'vitepress'
+
+const V2_URL = 'https://stock-sdk.linkdiary.cn/'
+// 末尾的 @1 是提示版本：将来想让已关闭过的用户再次看到，把它改成 @2 即可。
+const DISMISS_KEY = 'stock-sdk-docs:v2-upgrade-notice@1'
+
+const { lang } = useData()
+const isEn = computed(() => lang.value.toLowerCase().startsWith('en'))
+
+const t = computed(() =>
+  isEn.value
+    ? {
+        badge: 'v2',
+        text: 'Stock SDK v2 is out — you are viewing the v1 docs.',
+        cta: 'Go to v2',
+        close: 'Dismiss',
+      }
+    : {
+        badge: 'v2',
+        text: 'Stock SDK v2 已发布，当前为 v1 文档。',
+        cta: '前往 v2 新版',
+        close: '关闭提示',
+      }
+)
+
+const visible = ref(false)
+const bannerEl = ref<HTMLElement | null>(null)
+let ro: ResizeObserver | null = null
+
+/** 把横幅实测高度写进 --vp-layout-top-height，让 VitePress 给横幅腾出顶部空间。 */
+function syncTopHeight() {
+  if (!bannerEl.value) return
+  const h = bannerEl.value.offsetHeight
+  document.documentElement.style.setProperty('--vp-layout-top-height', `${h}px`)
+}
+
+function clearTopHeight() {
+  document.documentElement.style.setProperty('--vp-layout-top-height', '0px')
+}
+
+function dismiss() {
+  visible.value = false
+  clearTopHeight()
+  try {
+    localStorage.setItem(DISMISS_KEY, '1')
+  } catch {
+    /* localStorage 不可用（隐私模式等）时静默：本次会话内关闭即可 */
+  }
+}
+
+onMounted(() => {
+  let dismissed = false
+  try {
+    dismissed = localStorage.getItem(DISMISS_KEY) === '1'
+  } catch {
+    /* 读不到就当未关闭，正常展示 */
+  }
+  if (dismissed) return
+
+  visible.value = true
+  nextTick(() => {
+    syncTopHeight()
+    // 文字在窄屏可能折行导致高度变化，用 ResizeObserver 持续校正。
+    if (typeof ResizeObserver !== 'undefined' && bannerEl.value) {
+      ro = new ResizeObserver(syncTopHeight)
+      ro.observe(bannerEl.value)
+    }
+  })
+})
+
+onBeforeUnmount(() => {
+  ro?.disconnect()
+  ro = null
+  if (visible.value) clearTopHeight()
+})
+</script>
+
+<template>
+  <div v-if="visible" ref="bannerEl" class="v2-banner" role="region" aria-label="version notice">
+    <div class="v2-banner__inner">
+      <span class="v2-banner__badge">{{ t.badge }}</span>
+      <span class="v2-banner__text">{{ t.text }}</span>
+      <a class="v2-banner__cta" :href="V2_URL" target="_blank" rel="noreferrer">
+        {{ t.cta }}
+        <span class="v2-banner__arrow" aria-hidden="true">→</span>
+      </a>
+    </div>
+    <button class="v2-banner__close" type="button" :aria-label="t.close" :title="t.close" @click="dismiss">
+      <svg width="11" height="11" viewBox="0 0 11 11" aria-hidden="true">
+        <path
+          d="M1 1l9 9M10 1L1 10"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          fill="none"
+        />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.v2-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  /* 高于固定导航，确保横幅始终压在最上层；导航已被 --vp-layout-top-height 下移 */
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 40px;
+  padding: 7px 52px 7px 20px; /* 右侧多留出 × 的空间 */
+  font-family: var(--font-display, inherit);
+  /* 磨砂玻璃 + 品牌暖色微染，呼应导航栏与首页背景 */
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--vp-c-brand-soft) 70%, var(--vp-c-bg)),
+    color-mix(in srgb, var(--vp-c-bg) 78%, transparent)
+  );
+  backdrop-filter: blur(14px) saturate(180%);
+  -webkit-backdrop-filter: blur(14px) saturate(180%);
+  border-bottom: 1px solid color-mix(in srgb, var(--vp-c-brand-1) 32%, var(--vp-c-divider));
+  box-shadow: 0 2px 16px -10px var(--glow-color, rgba(248, 113, 113, 0.3));
+}
+
+.v2-banner__inner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 12px;
+  max-width: 1100px;
+  line-height: 1.4;
+}
+
+/* mono 渐变「v2」徽标，复用 hero 的 accent gradient 语言 */
+.v2-banner__badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #fff;
+  background: var(--accent-gradient, linear-gradient(135deg, #f87171 0%, #fb923c 100%));
+  border-radius: 999px;
+  box-shadow: 0 2px 10px -3px var(--glow-color, rgba(248, 113, 113, 0.4));
+}
+
+.v2-banner__text {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+}
+
+.v2-banner__cta {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.84rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--vp-c-brand-2);
+  transition: color 0.2s;
+}
+.v2-banner__cta:hover {
+  color: var(--vp-c-brand-1);
+}
+.v2-banner__arrow {
+  font-family: var(--font-mono, monospace);
+}
+
+.v2-banner__close {
+  position: absolute;
+  top: 50%;
+  right: 14px;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  color: var(--vp-c-text-2);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: color 0.2s, background 0.2s, border-color 0.2s;
+}
+.v2-banner__close:hover {
+  color: var(--vp-c-brand-1);
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 60%, transparent);
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 30%, transparent);
+}
+
+/* 窄屏：缩字号、行内紧凑，× 仍固定在右上 */
+@media (max-width: 640px) {
+  .v2-banner {
+    padding: 6px 44px 6px 14px;
+  }
+  .v2-banner__inner {
+    gap: 6px 8px;
+  }
+  .v2-banner__text {
+    font-size: 0.78rem;
+  }
+  .v2-banner__cta {
+    font-size: 0.78rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .v2-banner__cta,
+  .v2-banner__arrow,
+  .v2-banner__close {
+    transition: none;
+  }
+}
+</style>

--- a/website/en/guide/browser.md
+++ b/website/en/guide/browser.md
@@ -14,7 +14,7 @@ Stock SDK is designed to work seamlessly in browser environments.
   <div id="app"></div>
   
   <script type="module">
-    import { StockSDK } from 'https://unpkg.com/stock-sdk/dist/index.js';
+    import { StockSDK } from 'https://unpkg.com/stock-sdk@1.10.1/dist/index.js';
     
     const sdk = new StockSDK();
     
@@ -143,4 +143,3 @@ Never disable CORS in production. Always use proper proxy solutions.
 
 - [Technical Indicators](/en/guide/indicators)
 - [Batch Query](/en/guide/batch)
-

--- a/website/en/guide/getting-started.md
+++ b/website/en/guide/getting-started.md
@@ -5,7 +5,7 @@ This page covers the most common setup path. By default, create one `StockSDK` i
 ## Installation
 
 ```bash
-npm install stock-sdk
+npm install stock-sdk@1.10.1
 ```
 
 ## Create an Instance

--- a/website/en/guide/installation.md
+++ b/website/en/guide/installation.md
@@ -5,15 +5,15 @@
 ::: code-group
 
 ```bash [npm]
-npm install stock-sdk
+npm install stock-sdk@1.10.1
 ```
 
 ```bash [yarn]
-yarn add stock-sdk
+yarn add stock-sdk@1.10.1
 ```
 
 ```bash [pnpm]
-pnpm add stock-sdk
+pnpm add stock-sdk@1.10.1
 ```
 
 :::
@@ -25,13 +25,13 @@ For browser usage, you can use unpkg or jsDelivr:
 ```html
 <!-- unpkg -->
 <script type="module">
-  import { StockSDK } from 'https://unpkg.com/stock-sdk/dist/index.js';
+  import { StockSDK } from 'https://unpkg.com/stock-sdk@1.10.1/dist/index.js';
   const sdk = new StockSDK();
 </script>
 
 <!-- jsDelivr -->
 <script type="module">
-  import { StockSDK } from 'https://cdn.jsdelivr.net/npm/stock-sdk/dist/index.js';
+  import { StockSDK } from 'https://cdn.jsdelivr.net/npm/stock-sdk@1.10.1/dist/index.js';
   const sdk = new StockSDK();
 </script>
 ```
@@ -56,4 +56,3 @@ const quotes: FullQuote[] = await sdk.getFullQuotes(['sz000858']);
 
 - [Quick Start](/en/guide/getting-started) - Start using Stock SDK
 - [Browser Usage](/en/guide/browser) - Using in browser environment
-

--- a/website/guide/browser.md
+++ b/website/guide/browser.md
@@ -17,7 +17,7 @@ Stock SDK 完全支持在浏览器环境中使用，无需任何额外配置。
   <div id="result"></div>
 
   <script type="module">
-    import { StockSDK } from 'https://unpkg.com/stock-sdk/dist/index.js';
+    import { StockSDK } from 'https://unpkg.com/stock-sdk@1.10.1/dist/index.js';
 
     const sdk = new StockSDK();
     const quotes = await sdk.getFullQuotes(['sz000858', 'sh600519']);

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -5,7 +5,7 @@
 ## 安装
 
 ```bash
-npm install stock-sdk
+npm install stock-sdk@1.10.1
 ```
 
 ## 创建实例

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -5,15 +5,15 @@
 ::: code-group
 
 ```bash [npm]
-npm install stock-sdk
+npm install stock-sdk@1.10.1
 ```
 
 ```bash [yarn]
-yarn add stock-sdk
+yarn add stock-sdk@1.10.1
 ```
 
 ```bash [pnpm]
-pnpm add stock-sdk
+pnpm add stock-sdk@1.10.1
 ```
 
 :::
@@ -24,7 +24,7 @@ pnpm add stock-sdk
 
 ```html
 <script type="module">
-  import { StockSDK } from 'https://unpkg.com/stock-sdk/dist/index.js';
+  import { StockSDK } from 'https://unpkg.com/stock-sdk@1.10.1/dist/index.js';
 
   const sdk = new StockSDK();
   const quotes = await sdk.getFullQuotes(['sz000858']);

--- a/website/summary.md
+++ b/website/summary.md
@@ -160,4 +160,3 @@
 - [期货与期权](/guide/futures-options)
 - [分红与交易日历](/guide/dividend-calendar)
 - [API 总览](/api/)
-


### PR DESCRIPTION
## 改动

文档站（封存的 v1）两处全局调整：

### 1. 新增可关闭的 v2 升级提示条（`V2Banner.vue`）
- 挂在全站 `layout-top` 插槽，引导访客前往 v2 文档站 `https://stock-sdk.linkdiary.cn/`
- **可关闭**：点 × 后写 `localStorage`，后续访问不再出现（改 `DISMISS_KEY` 末尾版本号可重新对所有人弹出）
- **不遮挡导航**：用 VitePress 官方公告栏机制，把横幅实测高度写入 `--vp-layout-top-height`，固定导航 / 内容 / 侧边栏自动下移
- **风格统一**：复用站点珊瑚红品牌色 + `--accent-gradient` 渐变 + 磨砂玻璃，mono 字体 `v2` 徽标；明暗主题、中英文均适配
- 文案只陈述「v2 已发布、当前为 v1 文档」，不杜撰 v2 特性

### 2. 暂时下线 AI 问答助手入口（`Layout.vue`）
- 注释掉 `layout-bottom` 的 `ChatBot` 挂载（保留组件代码，便于恢复）

## 验证
- `npm run docs:check` 构建通过
- dev server 实测：明/暗主题、中英文、关闭按钮、刷新持久化、布局回弹均正常