### PR TITLE
fix(fund): 修复主题基金 API、下线 getHotThemes，发布 v2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 .vscode/
 .cursor/*
 !.cursor/rules/
+.opencode/
 *.swp
 *.swo
 

--- a/docs-meta/sdk.json
+++ b/docs-meta/sdk.json
@@ -237,7 +237,9 @@
           "fund.navHistory",
           "fund.estimate",
           "fund.rankHistory",
-          "fund.profile"
+          "fund.profile",
+          "fund.theme.getThemeList",
+          "fund.theme.getThemeFunds"
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/providers/eastmoney/fundTheme.ts
+++ b/src/providers/eastmoney/fundTheme.ts
@@ -3,7 +3,6 @@
  *
  * 数据源：https://fundmobapi.eastmoney.com/FundMNewApi/
  */
-import { SdkError } from '../../core/errors';
 import { toFiniteNumberOrNull } from '../../core/parser';
 import type { RequestClient } from '../../core/request';
 import type {
@@ -179,7 +178,7 @@ export async function getThemeFunds(
 ): Promise<ThemeFundItemList> {
   const sortColumn = options.sortColumn ?? 'SYL_1N';
   const sort = options.sort ?? 'desc';
-  const pageIndex = options.pageIndex ?? 1;
+  const page = options.page ?? 1;
   const pageSize = options.pageSize ?? 20;
   const fundType = options.fundType ?? '';
 
@@ -188,7 +187,7 @@ export async function getThemeFunds(
     TOPICAL: themeCode,
     SortColumn: sortColumn,
     Sort: sort,
-    pageIndex: String(pageIndex),
+    pageIndex: String(page),
     pageSize: String(pageSize),
     FundType: fundType,
   });
@@ -218,7 +217,7 @@ export async function getThemeFunds(
   });
 
   const data = payload.Data ?? [];
-  const fundInfo = payload.fundinfo ?? { total: 0, pagesize: pageSize, pageindex: pageIndex };
+  const fundInfo = payload.fundinfo ?? { total: 0, pagesize: pageSize, pageindex: page };
 
   const items: ThemeFundItem[] = data.map((item: NonNullable<typeof payload.Data>[number]) => ({
     code: item.fscode ?? '',
@@ -230,14 +229,14 @@ export async function getThemeFunds(
     quarterlyReturn: toFiniteNumberOrNull(item.SYL_3Y),
     yearlyReturn: toFiniteNumberOrNull(item.SYL_1N),
     nav: toFiniteNumberOrNull(item.dwjz),
+    // themeName 省略：上游 FundMNRank 不返回主题名称，仅回填 themeCode，调用方自行映射
     themeCode: themeCode,
-    themeName: '', // 上游不返回主题名称，调用方需自行维护映射
   }));
 
   return {
     items,
     total: fundInfo.total ?? 0,
-    pageIndex: fundInfo.pageindex ?? pageIndex,
+    pageIndex: fundInfo.pageindex ?? page,
     pageSize: fundInfo.pagesize ?? pageSize,
   };
 }

--- a/src/sdk/fundService.ts
+++ b/src/sdk/fundService.ts
@@ -13,10 +13,8 @@ import type {
   FundProfile,
   FundRankHistory,
   GetThemeListOptions,
-  GetHotThemesOptions,
   GetThemeFundsOptions,
   ThemeFundListResult,
-  HotThemesResult,
   ThemeFundItemList,
 } from '../types';
 import type { RequestClient } from '../core';
@@ -49,7 +47,7 @@ export class FundService extends BaseService {
     return eastmoney.getFundRankHistory(this.client, code);
   }
 
-/**
+  /**
    * 获取基金深度资料（一次请求返回全量字段）。
    *
    * 包含：前十大重仓股、资产配置、仓位测算、基金经理、业绩评价、
@@ -74,10 +72,8 @@ export class FundThemeService {
     return eastmoney.getThemeList(this.client, options);
   }
 
-  /** 获取热门主题 */
-  getHotThemes(options?: GetHotThemesOptions): Promise<HotThemesResult> {
-    return eastmoney.getHotThemes(this.client, options);
-  }
+  // NOTE: getHotThemes 暂时下线 —— 上游 FundThemeList 接口不可用（反爬 / 404）。
+  // provider eastmoney.getHotThemes 与类型保留，待数据源修复后恢复本方法 + spec + 文档。
 
   /** 获取主题下基金列表 */
   getThemeFunds(

--- a/src/spec/methods.ts
+++ b/src/spec/methods.ts
@@ -1245,31 +1245,20 @@ export const METHOD_SPECS: MethodSpec[] = [
       { flag: 'page', type: 'number', cli: false, desc: '页码，默认1' },
     ],
   },
-  {
-    path: ['fund', 'theme', 'getHotThemes'],
-    toolName: 'get_hot_themes',
-    summary: '热门主题排行',
-    mcpDesc:
-      '获取热门主题基金排行（东方财富天天基金），按RankItems排序的热门主题列表，' +
-      '返回主题代码(code)、名称(name)、日涨幅及各阶段收益率。category=0(行业)/1(概念)/2(全部，默认)。',
-    argShape: 'options',
-    params: [
-      { flag: 'sort', type: 'string', cli: false, desc: '排序字段：ZDF(日涨幅)/SYL_W(近1周)/SYL_M(近1月)/SYL_3M(近3月)/SYL_6M(近6月)/SYL_Y(近1年)/SYL_3Y(近3年)/SYL_5Y(近5年)，默认ZDF' },
-      { flag: 'order', type: 'enum', enum: ['desc', 'asc'], default: 'desc', cli: false, desc: '排序方向：desc(降序，默认)/asc(升序)' },
-      { flag: 'category', type: 'enum', enum: ['0', '1', '2'], default: '2', cli: false, desc: '主题类型：0(行业)/1(概念)/2(全部，默认)' },
-    ],
-  },
+  // NOTE: fund.theme.getHotThemes 暂时下线 —— 上游 FundThemeList 接口不可用（反爬 / 404）。
+  // provider 实现（eastmoney.getHotThemes）与类型保留在 fundTheme.ts，待数据源修复后
+  // 恢复本 spec 条目 + FundThemeService.getHotThemes + 文档即可。
   {
     path: ['fund', 'theme', 'getThemeFunds'],
     toolName: 'get_theme_funds',
     summary: '主题下基金排行',
     mcpDesc:
-      '获取指定主题主题下的基金排行列表（东方财富天天基金）。themeCode为主题代码（如BK0438=食品饮料）。' +
+      '获取指定主题下的基金排行列表（东方财富天天基金）。themeCode为主题代码（如BK0438=食品饮料）。' +
       '可按日涨幅/各阶段收益率排序分页，返回基金代码、名称、基金类型、日涨幅及各阶段收益率、最新净值。',
     argShape: 'symbol+options',
     positional: [SYMBOL_REQ('主题代码，如 BK0438（食品饮料）')],
     params: [
-      { flag: 'sortColumn', type: 'string', cli: false, desc: '排序字段：RZDF(日涨幅)/SYL_Z(近1周)/SYL_Y(近1月)/SYL_3Y(近3月)/SYL_6Y(近6月)/SYL_1N(近1年)/SYL_3N(近3年)/SYL_5N(近5年)，默认SYL_1N' },
+      { flag: 'sortColumn', type: 'string', cli: false, desc: '排序字段：SYL_Z(近1周)/SYL_Y(近1月)/SYL_3Y(近3月)/SYL_1N(近1年，默认)/RZDF(日涨幅)' },
       { flag: 'sort', type: 'enum', enum: ['desc', 'asc'], default: 'desc', cli: false, desc: '排序方向：desc(降序，默认)/asc(升序)' },
       { flag: 'pageSize', type: 'number', cli: false, desc: '每页条数，默认10，最大30' },
       { flag: 'page', type: 'number', cli: false, desc: '页码，默认1' },

--- a/src/types/fund.ts
+++ b/src/types/fund.ts
@@ -402,7 +402,7 @@ export type ThemeFundRankSort =
 export interface GetThemeFundsOptions {
   sortColumn?: ThemeFundRankSort;
   sort?: ThemeFundOrder;
-  pageIndex?: number;
+  page?: number;
   pageSize?: number;
   fundType?: string;
 }
@@ -445,7 +445,8 @@ export interface ThemeFundItem {
   yearlyReturn: number | null;
   nav: number | null;
   themeCode: string;
-  themeName: string;
+  /** 主题名称：上游 FundMNRank 不返回，通常缺省，调用方可用 themeCode 自行映射 */
+  themeName?: string;
 }
 
 /** 主题下基金列表结果 */

--- a/test/integration/sdk/theme.int.test.ts
+++ b/test/integration/sdk/theme.int.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for theme fund API (real network requests)
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { StockSDK } from '../../../src';
 
 const sdk = new StockSDK();
@@ -17,14 +17,6 @@ describe.skipIf(!process.env.RUN_INTEGRATION)(
       expect(result.items[0].code).toMatch(/^BK\d{4}$/);
       expect(result.items[0].name).toBeDefined();
       expect(result.items[0].type).toMatch(/^行业|概念$/);
-    });
-
-    it('should fetch hot themes successfully', async () => {
-      const result = await sdk.fund.theme.getHotThemes({ limit: 10 });
-
-      expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0].code).toMatch(/^BK\d{4}$/);
     });
 
     it('should fetch funds by theme code', async () => {
@@ -47,9 +39,10 @@ describe.skipIf(!process.env.RUN_INTEGRATION)(
     });
 
     it('should handle invalid theme code gracefully', async () => {
-      await expect(
-        sdk.fund.theme.getThemeFunds('INVALID_CODE')
-      ).rejects.toThrow();
+      // 非法主题代码：上游返回空集，SDK 优雅降级为空列表而非抛异常
+      const result = await sdk.fund.theme.getThemeFunds('INVALID_CODE');
+      expect(Array.isArray(result.items)).toBe(true);
+      expect(typeof result.total).toBe('number');
     });
   },
   30000

--- a/test/unit/cli/manifest.test.ts
+++ b/test/unit/cli/manifest.test.ts
@@ -52,11 +52,11 @@ describe('findCommand — 命名空间 vs 别名歧义', () => {
 });
 
 describe('manifest 完整性', () => {
-  it('88 个命名空间方法 + 顶层 search', () => {
-    expect(namespaceMethodCount()).toBe(88);
+  it('87 个命名空间方法 + 顶层 search', () => {
+    expect(namespaceMethodCount()).toBe(87);
     const paths = allMethodPaths();
     expect(paths).toContain('search');
-    expect(paths.length).toBe(89);
+    expect(paths.length).toBe(88);
   });
 
   it('collectBooleanFlags 含全局、声明布尔与全部布尔指标 flag', () => {

--- a/test/unit/providers/eastmoney/fundTheme.test.ts
+++ b/test/unit/providers/eastmoney/fundTheme.test.ts
@@ -250,7 +250,7 @@ describe('eastmoney/fundTheme', () => {
       });
 
       await getThemeFunds(client, 'BK0438', {
-        pageIndex: 2,
+        page: 2,
         pageSize: 30,
         sortColumn: 'SYL_Y',
         sort: 'asc',

--- a/test/unit/spec/consistency.test.ts
+++ b/test/unit/spec/consistency.test.ts
@@ -44,11 +44,11 @@ function sharedParams(spec: MethodSpec): ParamSpec[] {
 }
 
 describe('spec 完整性与两端规模', () => {
-  it('89 个方法 spec；83 个 MCP 工具（6 个 CLI-only：batch.raw/blockTrade×3/margin×2）', () => {
-    expect(METHOD_SPECS.length).toBe(89);
-    expect(MCP_SPECS.length).toBe(83);
-    expect(TOOLS.length).toBe(83);
-    expect(NAMESPACE_COMMANDS.length).toBe(89);
+  it('88 个方法 spec；82 个 MCP 工具（6 个 CLI-only：batch.raw/blockTrade×3/margin×2）', () => {
+    expect(METHOD_SPECS.length).toBe(88);
+    expect(MCP_SPECS.length).toBe(82);
+    expect(TOOLS.length).toBe(82);
+    expect(NAMESPACE_COMMANDS.length).toBe(88);
   });
 
   it('工具名唯一且与 spec 的 toolName 一一对应，tier 归属一致', () => {

--- a/website/.vitepress/theme/components/playground/overrides.ts
+++ b/website/.vitepress/theme/components/playground/overrides.ts
@@ -83,6 +83,8 @@ export const DEFAULT_VALUES: Record<string, Record<string, string>> = {
   'fund.estimate': { code: '005827' },
   'fund.rankHistory': { code: '110011' },
   'fund.profile': { code: '000001' },
+  // ===== fund.theme（getThemeList 参数全可选，开箱即跑；getThemeFunds 必填主题代码；getHotThemes 暂下线）=====
+  'fund.theme.getThemeFunds': { symbol: 'BK0438' },
   // ===== reference / search =====
   'reference.dividendDetail': { symbol: '600519' },
   search: { keyword: '茅台' },

--- a/website/api/fund.md
+++ b/website/api/fund.md
@@ -398,33 +398,6 @@ interface ThemeFund {
 }
 ```
 
-## sdk.fund.theme.getHotThemes
-
-获取热门主题排行（东方财富天天基金），按指定排序字段返回 Top 主题列表。
-
-### 参数
-
-```ts
-interface GetHotThemesOptions {
-  /** 排序字段：ZDF(日涨幅)/SYL_W(近1周)/SYL_M(近1月)/SYL_3M(近3月)/SYL_6M(近6月)/SYL_Y(近1年)/SYL_3Y(近3年)/SYL_5Y(近5年)，默认 ZDF */
-  sort?: string;
-  /** 排序方向：desc(降序，默认)/asc(升序) */
-  order?: 'desc' | 'asc';
-  /** 主题类型：'0'(行业)/'1'(概念)/'2'(全部，默认) */
-  category?: '0' | '1' | '2';
-}
-```
-
-### 调用示例
-
-```ts
-// 获取热门主题，按近1周收益率降序
-const hot = await sdk.fund.theme.getHotThemes({ sort: 'SYL_W', order: 'desc' });
-console.log(hot.slice(0, 10).map(t => `${t.name}: weekly ${t.weeklyReturn}%`));
-```
-
-注意：`getHotThemes` 返回直接的 `ThemeFund[]` 数组（不是 `{ items }` 对象），可以直接遍历或切片。
-
 ## sdk.fund.theme.getThemeFunds
 
 获取指定主题下的基金排行列表。themeCode 为主题代码（如 `BK0438` = 食品饮料），可通过 `getThemeList` 获取。
@@ -433,7 +406,7 @@ console.log(hot.slice(0, 10).map(t => `${t.name}: weekly ${t.weeklyReturn}%`));
 
 ```ts
 interface GetThemeFundsOptions {
-  /** 排序字段：RZDF(日涨幅)/SYL_Z(近1周)/SYL_Y(近1月)/SYL_3Y(近3月)/SYL_6Y(近6月)/SYL_1N(近1年)/SYL_3N(近3年)/SYL_5N(近5年)，默认 SYL_1N */
+  /** 排序字段：SYL_Z(近1周)/SYL_Y(近1月)/SYL_3Y(近3月)/SYL_1N(近1年，默认)/RZDF(日涨幅) */
   sortColumn?: string;
   /** 排序方向：desc(降序，默认)/asc(升序) */
   sort?: 'desc' | 'asc';
@@ -465,9 +438,9 @@ funds.items.forEach(f => {
 ```ts
 interface ThemeFundItemList {
   items: ThemeFundItem[];
-  totalPages: number;
+  total: number;
+  pageIndex: number;
   pageSize: number;
-  currentPage: number;
 }
 
 interface ThemeFundItem {
@@ -481,7 +454,7 @@ interface ThemeFundItem {
   yearlyReturn: number | null;
   nav: number | null;
   themeCode: string;
-  themeName: string;
+  themeName?: string; // 上游不返回，通常缺省
 }
 ```
 

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -6,6 +6,16 @@ pageClass: changelog-page
 
 本页记录 Stock SDK 的版本更新历史。v2.0.0 是一次**架构跃迁**——在不扩展数据源的前提下，重做了符号模型、数据契约、API 表面、请求层与错误体系，并新增 CLI / MCP 与 subpath 导出。
 
+## v2.2.0
+
+> 发布时间：待发布
+
+### 新增
+
+- **主题基金 API `sdk.fund.theme.*`**：按行业 / 概念主题维度浏览基金，并同步派生到 CLI 与 MCP（`get_theme_list` / `get_theme_funds`）。
+  - `getThemeList(options?)` —— 全部主题列表（行业 / 概念，含日涨幅与近 1 周 / 1 月 / 3 月 / 6 月 / 1 年 / 3 年 / 5 年各阶段收益率，支持排序分页）
+  - `getThemeFunds(themeCode, options?)` —— 指定主题下的基金排行（含基金类型、各阶段收益率、最新净值）
+
 ## v2.1.0
 
 > 发布时间：2026-06-23

--- a/website/en/api/fund.md
+++ b/website/en/api/fund.md
@@ -389,30 +389,6 @@ interface ThemeFund {
 }
 ```
 
-## sdk.fund.theme.getHotThemes
-
-Get hot themes ranking (EastMoney / Tian Tian Fund). Returns top themes sorted by the specified field.
-
-### Parameters
-
-```ts
-interface GetHotThemesOptions {
-  sort?: string;          // Sort field: ZDF(daily)/SYL_W(1w)/SYL_M(1m)/SYL_3M(3m)/SYL_6M(6m)/SYL_Y(1y)/SYL_3Y(3y)/SYL_5Y(5y), default ZDF
-  order?: 'desc' | 'asc';// Sort direction: desc(default)/asc
-  category?: '0' | '1' | '2'; // Theme type: '0'(industry)/'1'(concept)/'2'(all, default)
-}
-```
-
-### Example
-
-```ts
-// Get hot themes sorted by 1-week return descending
-const hot = await sdk.fund.theme.getHotThemes({ sort: 'SYL_W', order: 'desc' });
-console.log(hot.slice(0, 10).map(t => `${t.name}: weekly ${t.weeklyReturn}%`));
-```
-
-Note: `getHotThemes` returns a direct `ThemeFund[]` array (not `{ items }`), so you can iterate or slice it directly.
-
 ## sdk.fund.theme.getThemeFunds
 
 Get funds under a specific theme. themeCode is the theme code (e.g. `BK0438` = Food & Beverage). Use `getThemeList` to find theme codes.
@@ -421,7 +397,7 @@ Get funds under a specific theme. themeCode is the theme code (e.g. `BK0438` = F
 
 ```ts
 interface GetThemeFundsOptions {
-  sortColumn?: string;    // Sort: RZDF(daily)/SYL_Z(1w)/SYL_Y(1m)/SYL_3Y(3m)/SYL_6Y(6m)/SYL_1N(1y)/SYL_3N(3y)/SYL_5N(5y), default SYL_1N
+  sortColumn?: string;    // Sort: SYL_Z(1w)/SYL_Y(1m)/SYL_3Y(3m)/SYL_1N(1y, default)/RZDF(daily)
   sort?: 'desc' | 'asc'; // Sort direction: desc(default)/asc
   pageSize?: number;      // Page size, default 10, max 30
   page?: number;          // Page number, default 1
@@ -448,9 +424,9 @@ funds.items.forEach(f => {
 ```ts
 interface ThemeFundItemList {
   items: ThemeFundItem[];
-  totalPages: number;
+  total: number;
+  pageIndex: number;
   pageSize: number;
-  currentPage: number;
 }
 
 interface ThemeFundItem {
@@ -464,7 +440,7 @@ interface ThemeFundItem {
   yearlyReturn: number | null;
   nav: number | null;
   themeCode: string;
-  themeName: string;
+  themeName?: string; // not returned upstream, usually absent
 }
 ```
 

--- a/website/en/changelog.md
+++ b/website/en/changelog.md
@@ -6,6 +6,16 @@ pageClass: changelog-page
 
 This page records the release history of Stock SDK. v2.0.0 is an **architectural leap** — without adding data sources, it reworks the symbol model, data contract, API surface, request layer, and error system, and adds a CLI / MCP and subpath exports.
 
+## v2.2.0
+
+> Released: TBD
+
+### Added
+
+- **Theme fund API `sdk.fund.theme.*`**: browse funds by industry / concept theme, also derived to the CLI and MCP (`get_theme_list` / `get_theme_funds`).
+  - `getThemeList(options?)` — full theme list (industry / concept, with daily change and 1W / 1M / 3M / 6M / 1Y / 3Y / 5Y stage returns, sortable and paginated)
+  - `getThemeFunds(themeCode, options?)` — fund ranking within a theme (fund type, stage returns, latest NAV)
+
 ## v2.1.0
 
 > Released: 2026-06-23

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -4,7 +4,7 @@
 > 单一事实源）与 `src/types` 自动生成，目的是让 AI 工具**一次性读取** stock-sdk 的全部
 > 命名空间方法、参数与返回数据结构。**请勿手改本文件**——改 spec / types 后重新生成。
 >
-> 版本：v2.1.0 · 文档站：https://stock-sdk.linkdiary.cn · npm: `npm i stock-sdk`
+> 版本：v2.2.0 · 文档站：https://stock-sdk.linkdiary.cn · npm: `npm i stock-sdk`
 
 ## 这是什么
 
@@ -44,7 +44,7 @@ import { screen, backtest } from 'stock-sdk/screener';
 
 ### 安装与模块格式
 
-- 最新版：`npm i stock-sdk`（当前 v2.1.0）
+- 最新版：`npm i stock-sdk`（当前 v2.2.0）
 - v1 旧版（已封存）：`npm i stock-sdk@legacy`
 - **ESM + CommonJS** 双格式；主包 `import { StockSDK } from 'stock-sdk'`
 - 纯计算 subpath：`stock-sdk/{indicators,signals,symbols,screener,cache,errors,mcp}`（tree-shake 友好，不拖入全部 provider）
@@ -96,7 +96,7 @@ Cursor / Claude Desktop 等配置 `mcpServers`：`{ "command": "npx", "args": ["
 
 ---
 
-## 一、命名空间方法（共 89 个）
+## 一、命名空间方法（共 88 个）
 
 > 形如 `sdk.quotes.cn(codes)` / `sdk.kline.cn(symbol, options?)`；`codes[]` 形态的方法第一个参数为 **string[]**。
 > 标注 **CLI 专属** 的参数/flag 不应传入 SDK options（除非文档明确说明 SDK 消费）。
@@ -407,13 +407,9 @@ Cursor / Claude Desktop 等配置 `mcpServers`：`{ "command": "npx", "args": ["
     - `options.category` (0 | 1 | 2, 默认 2, SDK / MCP): 主题类型：0(行业)/1(概念)/2(全部，默认)
     - `options.pageSize` (number, SDK / MCP): 每页条数，默认20，最大50
     - `options.page` (number, SDK / MCP): 页码，默认1
-- **`sdk.fund.theme.getHotThemes(options?)`** — 获取热门主题基金排行（东方财富天天基金），按RankItems排序的热门主题列表，返回主题代码(code)、名称(name)、日涨幅及各阶段收益率。category=0(行业)/1(概念)/2(全部，默认)。
-    - `options.sort` (string, SDK / MCP): 排序字段：ZDF(日涨幅)/SYL_W(近1周)/SYL_M(近1月)/SYL_3M(近3月)/SYL_6M(近6月)/SYL_Y(近1年)/SYL_3Y(近3年)/SYL_5Y(近5年)，默认ZDF
-    - `options.order` (desc | asc, 默认 desc, SDK / MCP): 排序方向：desc(降序，默认)/asc(升序)
-    - `options.category` (0 | 1 | 2, 默认 2, SDK / MCP): 主题类型：0(行业)/1(概念)/2(全部，默认)
-- **`sdk.fund.theme.getThemeFunds(symbol, options?)`** — 获取指定主题主题下的基金排行列表（东方财富天天基金）。themeCode为主题代码（如BK0438=食品饮料）。可按日涨幅/各阶段收益率排序分页，返回基金代码、名称、基金类型、日涨幅及各阶段收益率、最新净值。
+- **`sdk.fund.theme.getThemeFunds(symbol, options?)`** — 获取指定主题下的基金排行列表（东方财富天天基金）。themeCode为主题代码（如BK0438=食品饮料）。可按日涨幅/各阶段收益率排序分页，返回基金代码、名称、基金类型、日涨幅及各阶段收益率、最新净值。
     - `symbol` (位置参数, 必填): 主题代码，如 BK0438（食品饮料）
-    - `options.sortColumn` (string, SDK / MCP): 排序字段：RZDF(日涨幅)/SYL_Z(近1周)/SYL_Y(近1月)/SYL_3Y(近3月)/SYL_6Y(近6月)/SYL_1N(近1年)/SYL_3N(近3年)/SYL_5N(近5年)，默认SYL_1N
+    - `options.sortColumn` (string, SDK / MCP): 排序字段：SYL_Z(近1周)/SYL_Y(近1月)/SYL_3Y(近3月)/SYL_1N(近1年，默认)/RZDF(日涨幅)
     - `options.sort` (desc | asc, 默认 desc, SDK / MCP): 排序方向：desc(降序，默认)/asc(升序)
     - `options.pageSize` (number, SDK / MCP): 每页条数，默认10，最大30
     - `options.page` (number, SDK / MCP): 页码，默认1
@@ -1859,7 +1855,7 @@ export type ThemeFundRankSort =
 export interface GetThemeFundsOptions {
   sortColumn?: ThemeFundRankSort;
   sort?: ThemeFundOrder;
-  pageIndex?: number;
+  page?: number;
   pageSize?: number;
   fundType?: string;
 }
@@ -1902,7 +1898,8 @@ export interface ThemeFundItem {
   yearlyReturn: number | null;
   nav: number | null;
   themeCode: string;
-  themeName: string;
+  /** 主题名称：上游 FundMNRank 不返回，通常缺省，调用方可用 themeCode 自行映射 */
+  themeName?: string;
 }
 
 /** 主题下基金列表结果 */

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,7 +1,7 @@
 # stock-sdk
 
 > 零依赖股票行情 SDK（A 股 / 港股 / 美股 / 基金 / 期货 / 期权），浏览器 + Node.js 双端；
-> 命名空间 API，自带 CLI 与内置 MCP server。版本 v2.1.0。
+> 命名空间 API，自带 CLI 与内置 MCP server。版本 v2.2.0。
 
 给 AI / LLM 工具的**完整 API**（全部方法 / 参数 / 数据结构，一次性读取）：
 

--- a/website/summary.md
+++ b/website/summary.md
@@ -5,7 +5,7 @@
 ## 项目定位
 
 - 包名：`stock-sdk`
-- 当前版本：`2.1.0`
+- 当前版本：`2.2.0`
 - 定位：面向前端与 Node.js 的股票行情 SDK，支持多市场行情、K 线、指标、期货、期权和 AI / MCP 集成
 - 核心卖点：零依赖 | Browser + Node.js | 轻量发布包 | 完整 TypeScript 类型
 
@@ -13,7 +13,7 @@
 
 | 文件 | 体积 | Gzip |
 | --- | --- | --- |
-| `dist/index.js` | 3.53 KB | 1.61 KB |
+| `dist/index.js` | 3.53 KB | 1.60 KB |
 | `dist/index.cjs` | 5.06 KB | 1.70 KB |
 
 ## 请求治理能力
@@ -166,6 +166,8 @@
 - `fund.estimate`
 - `fund.rankHistory`
 - `fund.profile`
+- `fund.theme.getThemeList`
+- `fund.theme.getThemeFunds`
 
 ## 相关页面
 


### PR DESCRIPTION
## 背景

PR #45 合入 master 后，`docs:check` CI 变红：`fund.theme.*` 方法未登记进 `docs-meta/sdk.json` 的 `summary.methodGroups`，反向覆盖闸报 3 条 `SDK method is not listed in any summary.methodGroups`。本 PR 修复该问题并把主题基金功能收口为 **v2.2.0**。

## 改动

- **修复 docs:check CI**：将 `fund.theme.getThemeList` / `getThemeFunds` 登记进 `docs-meta/sdk.json`，重生成 `summary.md` / `llms*`。
- **下线 `getHotThemes`**：上游 `FundThemeList` 接口反爬 / 404 不可用，从 spec / facade / 文档 / playground 移除；provider 实现与类型保留，待数据源修复后恢复（代码内有 `NOTE` 标注恢复方式）。
- **修正 `getThemeFunds`**：分页入参统一为 `page`；`ThemeFundItemList` 返回类型文档（中英）改为 `{ items, total, pageIndex, pageSize }`；`sortColumn` 裁剪至实际支持值；`ThemeFundItem.themeName` 改为可选。
- **playground**：为 `getThemeFunds` 预置必填主题代码 `BK0438`。
- **发布 v2.2.0**：`package.json` `2.1.0 → 2.2.0`，补充中英文 changelog（仅记相对 2.1.0 的净增点）。

## 本地验证

| 命令 | 结果 |
| --- | --- |
| `pnpm typecheck` | ✅ |
| `pnpm test` | ✅ 1001 passed |
| `pnpm docs:check` | ✅（88 命名空间方法，CI 红已修复） |
| `pnpm build:pages` | ✅ build complete |

## 备注

主题基金数据源为天天基金 App 接口（`fundmobapi.eastmoney.com`），带反爬保护。本版仅上线 `getThemeList` / `getThemeFunds`，`getHotThemes` 待数据源可用后再补。
