### PR TITLE
Add FXMacroData integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,16 @@
         "default": "./dist/errors.cjs"
       }
     },
+    "./fxmacrodata": {
+      "import": {
+        "types": "./dist/fxmacrodata.d.ts",
+        "default": "./dist/fxmacrodata.js"
+      },
+      "require": {
+        "types": "./dist/fxmacrodata.d.cts",
+        "default": "./dist/fxmacrodata.cjs"
+      }
+    },
     "./mcp": {
       "import": {
         "types": "./dist/mcp.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,15 @@ export * from './types';
 // 导出外部财经链接工具
 export { generateSearchExternalLinks } from './externalLinks';
 
+// 导出 FXMacroData 宏观、外汇、COT、大宗商品与交易时段客户端
+export {
+  FXMacroDataClient,
+  createFXMacroDataClient,
+  type FXMacroDataClientOptions,
+  type FXMacroDataFetch,
+  type FXMacroDataParams,
+} from './providers/fxmacrodata';
+
 // 导出独立指标计算函数
 export {
   calcMA,

--- a/src/providers/fxmacrodata/index.ts
+++ b/src/providers/fxmacrodata/index.ts
@@ -1,0 +1,220 @@
+export type FXMacroDataParams = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+export type FXMacroDataFetch = (
+  input: string | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+export interface FXMacroDataClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  fetchImpl?: FXMacroDataFetch;
+  defaultParams?: FXMacroDataParams;
+}
+
+export class FXMacroDataClient {
+  static readonly defaultBaseUrl = 'https://fxmacrodata.com/api/v1/';
+
+  private readonly apiKey?: string;
+  private readonly baseUrl: URL;
+  private readonly fetchImpl: FXMacroDataFetch;
+  private readonly defaultParams: FXMacroDataParams;
+
+  constructor(options: FXMacroDataClientOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = new URL(options.baseUrl ?? FXMacroDataClient.defaultBaseUrl);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.defaultParams = options.defaultParams ?? {};
+  }
+
+  buildUrl(path: string, params: FXMacroDataParams = {}): URL {
+    const url = new URL(path.replace(/^\/+/, ''), this.baseUrl);
+    const merged = { ...this.defaultParams, ...params };
+
+    for (const [key, value] of Object.entries(merged)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+    if (this.apiKey) {
+      url.searchParams.set('api_key', this.apiKey);
+    }
+    return url;
+  }
+
+  async request<T = unknown>(
+    path: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    const url = this.buildUrl(path, params);
+    const response = await this.fetchImpl(url, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`FXMacroData HTTP ${response.status}: ${body}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  dataCatalogue<T = unknown>(currency: string): Promise<T> {
+    return this.request<T>(`data_catalogue/${normaliseCurrency(currency)}`);
+  }
+
+  announcements<T = unknown>(
+    currency: string,
+    indicator: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `announcements/${normaliseCurrency(currency)}/${indicator}`,
+      params
+    );
+  }
+
+  latestAnnouncements<T = unknown>(
+    currency: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `announcements/${normaliseCurrency(currency)}/latest`,
+      params
+    );
+  }
+
+  calendar<T = unknown>(
+    currency: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(`calendar/${normaliseCurrency(currency)}`, params);
+  }
+
+  predictions<T = unknown>(
+    currency: string,
+    indicator: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `predictions/${normaliseCurrency(currency)}/${indicator}`,
+      params
+    );
+  }
+
+  forex<T = unknown>(
+    base: string,
+    quote = 'usd',
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `forex/${normaliseCurrency(base)}/${normaliseCurrency(quote)}`,
+      params
+    );
+  }
+
+  cot<T = unknown>(
+    currency: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(`cot/${normaliseCurrency(currency)}`, params);
+  }
+
+  commodity<T = unknown>(
+    indicator: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(`commodities/${indicator}`, params);
+  }
+
+  commoditiesLatest<T = unknown>(
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>('commodities/latest', params);
+  }
+
+  curves<T = unknown>(
+    currency: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(`curves/${normaliseCurrency(currency)}`, params);
+  }
+
+  curveProxies<T = unknown>(
+    currency: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `curve_proxies/${normaliseCurrency(currency)}`,
+      params
+    );
+  }
+
+  forwardCurves<T = unknown>(
+    currency: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `forward_curves/${normaliseCurrency(currency)}`,
+      params
+    );
+  }
+
+  rateDifferentials<T = unknown>(
+    base: string,
+    quote = 'usd',
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `rate_differentials/${normaliseCurrency(base)}/${normaliseCurrency(quote)}`,
+      params
+    );
+  }
+
+  forwardDifferentials<T = unknown>(
+    base: string,
+    quote = 'usd',
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `forward_differentials/${normaliseCurrency(base)}/${normaliseCurrency(quote)}`,
+      params
+    );
+  }
+
+  marketSessions<T = unknown>(params: FXMacroDataParams = {}): Promise<T> {
+    return this.request<T>('market_sessions', params);
+  }
+
+  riskSentiment<T = unknown>(params: FXMacroDataParams = {}): Promise<T> {
+    return this.request<T>('risk_sentiment', params);
+  }
+
+  news<T = unknown>(
+    currency: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(`news/${normaliseCurrency(currency)}`, params);
+  }
+
+  pressReleases<T = unknown>(
+    currency: string,
+    params: FXMacroDataParams = {}
+  ): Promise<T> {
+    return this.request<T>(
+      `press-releases/${normaliseCurrency(currency)}`,
+      params
+    );
+  }
+}
+
+export function createFXMacroDataClient(
+  options: FXMacroDataClientOptions = {}
+): FXMacroDataClient {
+  return new FXMacroDataClient(options);
+}
+
+function normaliseCurrency(currency: string): string {
+  return currency.trim().toLowerCase();
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -11,3 +11,6 @@ export * as eastmoney from './eastmoney';
 // 新浪财经
 export * as sina from './sina';
 
+// FXMacroData macro, FX, COT, commodity, and session data
+export * as fxmacrodata from './fxmacrodata';
+

--- a/test/unit/providers/fxmacrodata.test.ts
+++ b/test/unit/providers/fxmacrodata.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { FXMacroDataClient } from '../../../src/providers/fxmacrodata';
+
+describe('FXMacroDataClient', () => {
+  it('builds authenticated API URLs', () => {
+    const client = new FXMacroDataClient({
+      apiKey: 'test-key',
+      baseUrl: 'https://example.com/api/v1/',
+    });
+
+    expect(client.buildUrl('/forex/EUR/USD', { limit: 1 }).toString()).toBe(
+      'https://example.com/api/v1/forex/EUR/USD?limit=1&api_key=test-key'
+    );
+  });
+
+  it('uses injected fetch implementations', async () => {
+    const requested: string[] = [];
+    const client = new FXMacroDataClient({
+      baseUrl: 'https://example.com/api/v1/',
+      fetchImpl: async (input) => {
+        requested.push(String(input));
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      },
+    });
+
+    await expect(client.calendar('usd', { limit: 3 })).resolves.toEqual({
+      data: [],
+    });
+    expect(requested[0]).toBe(
+      'https://example.com/api/v1/calendar/usd?limit=3'
+    );
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     screener: 'src/screener/index.ts',
     cache: 'src/cache/index.ts',
     errors: 'src/errors/index.ts',
+    fxmacrodata: 'src/providers/fxmacrodata/index.ts',
     cli: 'src/cli/index.ts',
     mcp: 'src/mcp/server.ts',
   },


### PR DESCRIPTION
## Summary
- add a zero-dependency FXMacroData TypeScript client with endpoint helpers for macro, FX, COT, commodities, sessions, sentiment, news, and press releases
- expose it from the root package and a new ./fxmacrodata subpath
- add unit coverage for URL construction and injected fetch behavior

## Validation
- .\node_modules\.bin\vitest.cmd run test/unit/providers/fxmacrodata.test.ts
- git diff --check

Note: pnpm docs:meta was blocked locally by pnpm ignored-builds approval before docs generation; no generated docs files were changed.